### PR TITLE
Fix Dockerfile path in GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+      run: docker build ./api --file ./api/Dockerfile --tag my-image-name:$(date +%s)


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow located in `.github/workflows/docker-image.yml` to correctly reference the Dockerfile in the `./api` directory instead of the root directory. This change resolves the error encountered during the build process, which was caused by the GitHub Actions workflow not being able to locate the Dockerfile. The Docker build command has been modified to use the path `./api/Dockerfile`, ensuring that the workflow correctly builds the Docker image. This fix should prevent future build failures related to missing Dockerfile references.

---

> This pull request was co-created with Cosine Genie

Original Task: [Uptown-FS/33vd2yugwdem](https://cosine.sh/epj61kf07sll/Uptown-FS/task/33vd2yugwdem)
Author: ramynoureldien
