### PR TITLE
Fix Docker Publish Workflow Environment Variables

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,12 +30,12 @@ jobs:
             context: ./api
             file: ./api/Dockerfile
             images: |
-              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-api
+              ghcr.io/${{ github.repository }}
+              ghcr.io/${{ github.repository }}-api
           - id: client
             context: ./client
             file: ./client/Dockerfile
-            images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-client
+            images: ghcr.io/${{ github.repository }}-client
 
     permissions:
       contents: read


### PR DESCRIPTION
This pull request updates the Docker publishing workflow to fix errors related to unrecognized environment variables. The previous usage of 'env.REGISTRY' and 'env.IMAGE_NAME' has been replaced with the GitHub Container Registry URL format, which uses 'ghcr.io/${{ github.repository }}'. This change ensures the workflow can properly reference the images for both API and client builds.

---

> This pull request was co-created with Cosine Genie

Original Task: [Uptown-FS/6jsbhcwlvk4v](https://cosine.sh/epj61kf07sll/Uptown-FS/task/6jsbhcwlvk4v)
Author: ramynoureldien
