### PR TITLE
Fix 404 Error on GET /api/auth/me

### DIFF
--- a/api/src/authRoutes.js
+++ b/api/src/authRoutes.js
@@ -269,7 +269,8 @@ router.post('/reset-password', async (req, res) => {
 router.get('/me', authMiddleware, async (req, res) => {
   try {
     const result = await pool.query('SELECT id, email, role FROM users WHERE id=$1', [req.user.id])
-    if (result.rows.length === 0) return res.status(404).json({ error: { message: 'User not found' } })
+    // If the token is valid but the user no longer exists, treat as unauthorized to trigger client logout/refresh.
+    if (result.rows.length === 0) return res.status(401).json({ error: { message: 'User not found' } })
     return res.json({ ok: true, user: result.rows[0] })
   } catch (e) {
     console.error('GET /api/auth/me error:', e)

--- a/client/src/admin/Users.jsx
+++ b/client/src/admin/Users.jsx
@@ -91,7 +91,7 @@ export default function Users() {
                 const errorData = await resp.json().catch(() => ({ error: { message: 'An unknown error occurred' } }));
                 throw new Error(errorData.error?.message || 'Failed to create user');
             }
-            await load(); // Refresh user list
+            await loadData(); // Refresh user list
             setCreateForm({ email: '', password: '', role: 'user' }); // Reset form
         }).finally(() => setCreating(false));
     };


### PR DESCRIPTION
This PR modifies the authentication route to return a 401 status instead of a 404 when a valid token is used but no user is found. This change ensures that the client properly handles unauthorized access, prompting a logout or refresh. Additionally, it corrects a function name in `Users.jsx` from `load()` to `loadData()` to ensure the user list refreshes correctly after user creation.

---

> This pull request was co-created with Cosine Genie

Original Task: [Uptown-FS/d5ktmfka00po](https://cosine.sh/epj61kf07sll/Uptown-FS/task/d5ktmfka00po)
Author: ramynoureldien
