### PR TITLE
Restrict Role Assignment to Super Admin Only

### DIFF
--- a/client/src/admin/UserEdit.jsx
+++ b/client/src/admin/UserEdit.jsx
@@ -28,6 +28,7 @@ export default function UserEdit() {
   const [audit, setAudit] = useState([])
 
   const me = JSON.parse(localStorage.getItem('auth_user') || '{}')
+  const isSuperAdmin = me?.role === 'superadmin'
 
   const roleOptions = [
     'user',
@@ -289,7 +290,7 @@ export default function UserEdit() {
           <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
             <label>
               <div style={metaText}>Role</div>
-              <select value={role} onChange={e => setRole(e.target.value)} disabled={isSelf} style={ctrl}>
+              <select value={role} onChange={e => setRole(e.target.value)} disabled={isSelf || !isSuperAdmin} style={ctrl}>
                 {roleOptions.map(r => <option key={r} value={r}>{r}</option>)}
               </select>
             </label>
@@ -311,7 +312,7 @@ export default function UserEdit() {
 
           <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
             <button type="submit" disabled={busy} style={btnPrimary}>Save email/notes/meta</button>
-            <button type="button" onClick={saveRole} disabled={busy || isSelf} style={btn}>Save role</button>
+            <button type="button" onClick={saveRole} disabled={busy || isSelf || !isSuperAdmin} style={btn}>Save role</button>
             <button type="button" onClick={saveActive} disabled={busy || isSelf} style={btnDanger}>{active ? 'Deactivate' : 'Activate'}</button>
           </div>
         </form>


### PR DESCRIPTION
This pull request modifies user role assignment capabilities within the admin panel. It restricts the ability to assign roles exclusively to super admins, preventing unauthorized role changes by regular admins. Additionally, it introduces safeguards in the user creation and editing interfaces to ensure that admins can only create users with the 'user' role, while super admins have the flexibility to assign any valid role. The changes also enhance the user interface to display appropriate options based on the user's role, ensuring clarity and preventing unauthorized access to sensitive role assignments.

---

> This pull request was co-created with Cosine Genie

Original Task: [Uptown-FS/djxxvvgxp8a4](https://cosine.sh/epj61kf07sll/Uptown-FS/task/djxxvvgxp8a4)
Author: ramynoureldien
