### PR TITLE
Add Sales Team Page Access for Admins

### DIFF
--- a/api/src/salesPeopleRoutes.js
+++ b/api/src/salesPeopleRoutes.js
@@ -5,7 +5,7 @@ import { authMiddleware } from './authRoutes.js'
 const router = express.Router()
 
 function adminOnly(req, res, next) {
-  if (req.user?.role !== 'admin') return res.status(403).json({ error: { message: 'Admin only' } })
+  if (!['admin', 'superadmin'].includes(req.user?.role)) return res.status(403).json({ error: { message: 'Admin only' } })
   next()
 }
 

--- a/client/src/lib/BrandHeader.jsx
+++ b/client/src/lib/BrandHeader.jsx
@@ -107,10 +107,11 @@ export default function BrandHeader({ title, onLogout }) {
           { label: 'Commissions Report', href: '/admin/commissions' }
         ]
       case 'admin':
-        // In this context, admin manages employees only: expose Users page only.
+        // In this context, admin manages employees: expose Users and Sales Team pages.
         return [
           ...base,
-          { label: 'Users', href: '/admin/users' }
+          { label: 'Users', href: '/admin/users' },
+          { label: 'Sales Team', href: '/admin/sales' }
         ]
       case 'financial_manager':
         return [

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -102,7 +102,7 @@ createRoot(document.getElementById('root')).render(
         <Route
           path="/admin/sales"
           element={
-            <RoleBasedRoute allowedRoles={['superadmin']}>
+            <RoleBasedRoute allowedRoles={['admin', 'superadmin']}>
               <SalesTeam />
             </RoleBasedRoute>
           }


### PR DESCRIPTION
This pull request addresses the issue of missing sales team page access for admin users. The changes made include:

1. **Updated Role Check**: Modified the middleware to allow both 'admin' and 'superadmin' roles to access specific routes, ensuring that admins can manage the sales team.
2. **Sales Team Page Inclusion**: Enhanced the BrandHeader component to expose the Sales Team page for admin users alongside the Users page.
3. **Route Permissions**: Updated the route for the Sales Team page to include both 'admin' and 'superadmin' in the allowed roles.

These changes ensure that admins can properly manage the sales team and employees as intended.

---

> This pull request was co-created with Cosine Genie

Original Task: [Uptown-FS/4cywy8jlaqox](https://cosine.sh/epj61kf07sll/Uptown-FS/task/4cywy8jlaqox)
Author: ramynoureldien
