### PR TITLE
Fix Vite HMR Configuration Issue

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -5,6 +5,14 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    port: 5173
+    port: 5173,
+    strictPort: true,
+    hmr: {
+      // In Docker or behind reverse proxies, the client may attempt to open
+      // a WS connection to the wrong host/port. Pin it explicitly.
+      protocol: 'ws',
+      host: process.env.HMR_HOST || 'localhost',
+      clientPort: Number(process.env.HMR_CLIENT_PORT || 5173)
+    }
   }
 })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,9 @@ services:
     environment:
       - NODE_ENV=development
       - VITE_API_URL=http://localhost:3000
+      # Ensure the browser connects HMR to the externally reachable host/port.
+      - HMR_HOST=localhost
+      - HMR_CLIENT_PORT=5173
     volumes:
       - ./client:/app
       - /app/node_modules


### PR DESCRIPTION
This pull request updates the Vite configuration to resolve a Hot Module Replacement (HMR) issue by setting strict port options and explicitly defining the HMR protocol, host, and client port. This change ensures that the correct WebSocket connection is used, especially when operating in Docker or behind reverse proxies.

---

> This pull request was co-created with Cosine Genie

Original Task: [Uptown-FS/y0itoky3znng](https://cosine.sh/epj61kf07sll/Uptown-FS/task/y0itoky3znng)
Author: ramynoureldien
