### PR TITLE
Fix access for payment thresholds route in top management

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -139,7 +139,7 @@ createRoot(document.getElementById('root')).render(
          <Route
            path="/admin/payment-thresholds"
            element={
-             <RoleBasedRoute allowedRoles={['admin', 'superadmin', 'financial_manager']}>
+             <RoleBasedRoute allowedRoles={['admin', 'superadmin', 'financial_manager', 'ceo', 'chairman', 'vice_chairman', 'top_management']}>
                <PaymentThresholds />
              </RoleBasedRoute>
            }


### PR DESCRIPTION
Updated the RoleBasedRoute for the '/admin/payment-thresholds' path to include additional roles: 'ceo', 'chairman', 'vice_chairman', and 'top_management'. This change ensures that the payment thresholds page is accessible to all necessary top management roles, resolving the issue where the page was pointing to the wrong access controls.

---

> This pull request was co-created with Cosine Genie

Original Task: [Uptown-FS/psjcq0rjfd9y](https://cosine.sh/epj61kf07sll/Uptown-FS/task/psjcq0rjfd9y)
Author: ramynoureldien
